### PR TITLE
기초 컴포넌트 개선 및 추가기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@hookform/error-message": "^2.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.2",
     "reset-css": "^5.0.2"
   },
   "devDependencies": {

--- a/src/components/container/container.stories.tsx
+++ b/src/components/container/container.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { DefaultPaddedContainer } from '@components/container/variants';
 import Container from '.';
 
 const meta: Meta<typeof Container> = {
@@ -48,11 +49,24 @@ export const CustomWidthHeight: Story = {
 
 export const CustomStyles: Story = {
   args: {
-    cssOverride: {
+    css: {
       border: '2px solid black',
       borderRadius: '10px',
       backgroundColor: '#f0f0f0',
     },
     padding: '20px',
   },
+};
+
+export const DefaultPadded: Story = {
+  args: {
+  },
+  render: () => (
+    <DefaultPaddedContainer css={{
+      border: '2px solid black',
+      borderRadius: '10px',
+      height: '200px',
+    }}
+    />
+  ),
 };

--- a/src/components/container/index.tsx
+++ b/src/components/container/index.tsx
@@ -1,7 +1,8 @@
-import { ReactNode } from 'react';
-import { css, CSSObject } from '@emotion/react';
+import { HTMLAttributes, ReactNode } from 'react';
+import { CSSObject } from '@emotion/react';
+import useContainerStyle from '@components/container/useContainerStyle';
 
-export interface ContainerProps {
+export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   direction?: 'row' | 'column';
   justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly';
@@ -11,40 +12,17 @@ export interface ContainerProps {
   gap?: string;
   padding?: string;
   boxSizing?: 'border-box' | 'content-box';
-  cssOverride?: CSSObject;
-}
-
-function StyledContainer({
-  children, direction, justify, align, width, height, gap, padding, boxSizing, cssOverride,
-}: ContainerProps) {
-  const style = css`
-    display: flex;
-    flex-direction: ${direction || 'row'};
-    justify-content: ${justify || 'center'};
-    align-items: ${align || 'center'};
-    width: ${width || '100%'};
-    height: ${height || 'auto'};
-    gap: ${gap || '0'};
-    padding: ${padding || '0'};
-    box-sizing: ${boxSizing || 'border-box'};
-  `;
-
-  return (
-    <div css={[style, cssOverride]}>
-      {children}
-    </div>
-  );
+  css?: CSSObject;
 }
 
 function Container({
-  children, ...rest
+  css, children, ...rest
 }: ContainerProps) {
+  const { containerStyle } = useContainerStyle(rest);
   return (
-    <StyledContainer
-      {...rest}
-    >
+    <div css={[containerStyle, css]} {...rest}>
       {children}
-    </StyledContainer>
+    </div>
   );
 }
 

--- a/src/components/container/useContainerStyle.tsx
+++ b/src/components/container/useContainerStyle.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import type { ContainerProps } from '@components/container/index';
+
+function useContainerStyle({
+  direction, justify, align, width, height, gap, padding, boxSizing,
+}: ContainerProps) {
+  const containerStyle = css`
+    display: flex;
+    flex-direction: ${direction || 'row'};
+    justify-content: ${justify || 'center'};
+    align-items: ${align || 'center'};
+    width: ${width || '100%'};
+    height: ${height || 'auto'};
+    gap: ${gap || '0'};
+    padding: ${padding || '0'};
+    box-sizing: ${boxSizing || 'border-box'};
+  `;
+  return {
+    containerStyle,
+  };
+}
+
+export default useContainerStyle;

--- a/src/components/container/variants/index.tsx
+++ b/src/components/container/variants/index.tsx
@@ -5,7 +5,7 @@ interface DefaultPaddedContainerProps extends ContainerProps {
 }
 
 export function DefaultPaddedContainer(
-  { children, ...rest }: DefaultPaddedContainerProps,
+  { children, css: cssOverride, ...rest }: DefaultPaddedContainerProps,
 ) {
   const paddedContainerStyle = css`
     box-sizing: border-box;
@@ -15,7 +15,7 @@ export function DefaultPaddedContainer(
   `;
 
   return (
-    <Container {...rest} cssOverride={paddedContainerStyle}>
+    <Container css={css([paddedContainerStyle, cssOverride])} {...rest}>
       {children}
     </Container>
   );

--- a/src/components/fallback/Spinner.stories.tsx
+++ b/src/components/fallback/Spinner.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Spinner from '@components/fallback/Spinner';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  argTypes: {
+    wrapperCss: { control: 'object' },
+    circleCss: { control: 'object' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {};

--- a/src/components/fallback/Spinner.tsx
+++ b/src/components/fallback/Spinner.tsx
@@ -1,0 +1,34 @@
+/** @jsxImportSource @emotion/react */
+import { css, keyframes, useTheme } from '@emotion/react';
+import Container from '@components/container';
+import { Paragraph } from '@components/text';
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+function Spinner() {
+  const theme = useTheme();
+  const spinnerStyle = css`
+    width: 30px;
+    height: 30px;
+    border: 5px solid ${theme.colors.border.subtle};
+    border-top: 5px solid ${theme.colors.primary.main};
+    border-radius: 50%;
+    margin-bottom: 15px;
+    animation: ${spin} 1s cubic-bezier(0.42, 0, 0.58, 1) infinite;
+`;
+  return (
+    <Container direction="column" padding="40px 0">
+      <div css={spinnerStyle} />
+      <Paragraph variant="small" color={theme.colors.text.moderate}>로드 중</Paragraph>
+    </Container>
+  );
+}
+
+export default Spinner;

--- a/src/components/grid/grid.stories.tsx
+++ b/src/components/grid/grid.stories.tsx
@@ -55,6 +55,10 @@ export const ResponsiveColumns: Story = {
       md: 3,
       lg: 4,
     },
-    children: <ChildComponent />,
   },
+  render: () => (
+    <Grid css={{ backgroundColor: 'blue' }} gap="0" columns={{ initial: 1, sm: 2, md: 3, lg: 4 }}>
+      <ChildComponent />
+    </Grid>
+  ),
 };

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -1,19 +1,19 @@
 import { css, CSSObject } from '@emotion/react';
-import { ReactNode } from 'react';
+import { HTMLAttributes, ReactNode } from 'react';
 import { breakPoints } from '@styles/breakpoints';
 import { BreakpointKey } from '@/styles';
 
 type ResponsiveColumns = number | Partial<Record<BreakpointKey, number>>;
 
-interface GridProps {
+interface GridProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   columns?: ResponsiveColumns;
   gap?: string;
-  cssOverride?: CSSObject;
+  css?: CSSObject;
 }
 
 function Grid({
-  children, columns, gap, cssOverride,
+  children, columns, gap, css: cssOverride, ...rest
 }: GridProps) {
   const gridStyle = css`
     display: grid;
@@ -21,7 +21,7 @@ function Grid({
   `;
   const columnStyle = getGridColumnStyle(columns);
   return (
-    <div css={[gridStyle, columnStyle, cssOverride]}>
+    <div css={css([gridStyle, columnStyle, cssOverride])} {...rest}>
       {children}
     </div>
   );

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -39,6 +39,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({
     throw new Error('Cannot enable toggle while the type of input is not password');
   }
 
+  let inputType = type === 'password' && isHidden ? 'password' : 'text';
+  if (type !== 'password') {
+    inputType = type;
+  }
+
   return (
     <>
       {
@@ -54,9 +59,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({
         <DynamicIcon icon={icon} css={inputIconStyle()} />
         <input
           css={[inputStyle, css]}
-          type={type === 'password' && isHidden
-            ? 'password'
-            : 'text'}
+          type={inputType}
           id={inputId.current}
           ref={ref}
           {...rest}

--- a/src/components/progressbar/index.tsx
+++ b/src/components/progressbar/index.tsx
@@ -1,0 +1,29 @@
+import useProgressBarStyle from '@components/progressbar/useProgressBarStyle';
+
+interface ProgressProps {
+  progress: number;
+  description?: string;
+  width?: string;
+}
+
+function ProgressBar({ progress, description = '', width = '100%' }: ProgressProps) {
+  const {
+    progressBarContainerStyle, progressWrapperStyle, progressStyle, textWrapperStyle,
+  } = useProgressBarStyle();
+  return (
+    <div css={progressBarContainerStyle}>
+      <div css={progressWrapperStyle(width)}>
+        <div css={progressStyle(progress)} />
+      </div>
+      <div css={textWrapperStyle(width)}>
+        <span>
+          {progress}
+          %
+        </span>
+        <span>{description}</span>
+      </div>
+    </div>
+  );
+}
+
+export default ProgressBar;

--- a/src/components/progressbar/progressbar.stories.tsx
+++ b/src/components/progressbar/progressbar.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProgressBar from '@/components/progressbar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Components/Progressbar',
+  component: ProgressBar,
+  argTypes: {
+    progress: { control: 'number' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const ProgressBarDefault: Story = {
+  args: {
+    progress: 50,
+    description: '완료율',
+  },
+};

--- a/src/components/progressbar/useProgressBarStyle.ts
+++ b/src/components/progressbar/useProgressBarStyle.ts
@@ -1,0 +1,48 @@
+import { css, useTheme } from '@emotion/react';
+
+function useProgressBarStyle() {
+  const theme = useTheme();
+  const progressBarContainerStyle = css`
+    align-items: center;
+    gap: 10px;
+  `;
+
+  const progressWrapperStyle = (width: string) => css`
+    width: ${width};
+    flex: 1;
+    height: 12px;
+    background-color: transparent;
+    border: 1px solid ${theme.colors.border.subtle};
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    box-sizing: border-box;
+    padding: 3px;
+  `;
+
+  const progressStyle = (progress: number) => css`
+    display: flex;
+    height: 50%;
+    justify-content: center;
+    align-items: center;
+    width: calc(${progress}% - 6px);
+    background-color: ${theme.colors.primary.main};
+    border-radius: 4px;
+    position: absolute;
+    top: 25%;
+  `;
+
+  const textWrapperStyle = (width: string) => css`
+    width: ${width};
+    display: flex;
+    justify-content: space-between;
+    padding: 4px;
+    color: ${theme.colors.text.moderate};
+    font-size: 12px;
+  `;
+  return {
+    progressBarContainerStyle, progressWrapperStyle, progressStyle, textWrapperStyle,
+  };
+}
+
+export default useProgressBarStyle;

--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, MouseEvent } from 'react';
+import { forwardRef, InputHTMLAttributes, MouseEvent } from 'react';
 import { CSSObject } from '@emotion/react';
 import useRadioStyle from '@components/radio/useRadioStyle';
 
@@ -9,17 +9,22 @@ interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
   checked?: boolean;
 }
 
-function Radio({ type = 'radio', ...rest }: RadioProps) {
-  const { radioStyle } = useRadioStyle();
+const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  (
+    { type = 'radio', ...rest },
+    ref,
+  ) => {
+    const { radioStyle } = useRadioStyle();
 
-  const onClick = (e: MouseEvent) => {
-    const input = e.target as HTMLInputElement;
-    input.checked = true;
-  };
+    const onClick = (e: MouseEvent) => {
+      const input = e.target as HTMLInputElement;
+      input.checked = true;
+    };
 
-  return (
-    <input type={type} css={radioStyle} onClick={onClick} {...rest} />
-  );
-}
+    return (
+      <input type={type} css={radioStyle} onClick={onClick} ref={ref} {...rest} />
+    );
+  },
+);
 
 export default Radio;

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -1,4 +1,6 @@
-import { ReactNode, SelectHTMLAttributes, useRef } from 'react';
+import {
+  forwardRef, ReactNode, SelectHTMLAttributes, useRef,
+} from 'react';
 import Label from '@components/label';
 import { CSSObject } from '@emotion/react';
 import useSelectStyle from '@components/select/useSelectStyle';
@@ -8,25 +10,23 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children?: ReactNode;
   icon?: string | ReactNode;
   label?: string;
-  placeholder?: string;
   css?: CSSObject;
 }
 
-function Select({
-  children, icon, label, placeholder, css, ...rest
-}: SelectProps) {
+const Select = forwardRef<HTMLSelectElement, SelectProps>(({
+  children, icon, label, css, ...rest
+}, ref) => {
   const selectId = useRef(generateRandomId());
   const { selectStyle, selectContainerStyle } = useSelectStyle();
 
   return (
     <div css={selectContainerStyle}>
       {label ? <Label>{label}</Label> : null}
-      <select id={selectId.current} css={[selectStyle, css]} {...rest}>
-        <option value="" selected disabled hidden>{placeholder}</option>
+      <select id={selectId.current} css={[selectStyle, css]} {...rest} ref={ref}>
         {children}
       </select>
     </div>
   );
-}
+});
 
 export default Select;

--- a/src/components/select/select.stories.tsx
+++ b/src/components/select/select.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof Select>;
 
 export const Default: Story = {
   render: () => (
-    <Select placeholder="옵션을 선택하세요." label="label" icon={eye}>
+    <Select label="label" icon={eye}>
       <option value="asdf">asdf</option>
       <option value="asdf">asdf</option>
       <option value="asdf">asdf</option>

--- a/src/components/spacing/index.tsx
+++ b/src/components/spacing/index.tsx
@@ -34,6 +34,5 @@ function getSpacingHeight(heights?: ResponsiveHeights) {
       }  
     `))
     .join(' ');
-  console.log(merged);
   return css(merged);
 }

--- a/src/components/switch/index.tsx
+++ b/src/components/switch/index.tsx
@@ -1,5 +1,5 @@
 import {
-  forwardRef, InputHTMLAttributes, useRef,
+  InputHTMLAttributes, useRef, useState,
 } from 'react';
 import { CSSObject } from '@emotion/react';
 import useSwitchHandler from '@components/switch/useSwitchHandler';
@@ -7,30 +7,34 @@ import useSwitchStyle from '@components/switch/useSwitchStyle';
 import { generateRandomId } from '@/utils';
 
 interface SwitchProps extends InputHTMLAttributes<HTMLInputElement> {
-  type: 'checkbox';
+  type?: 'checkbox';
   wrapperCss?: CSSObject;
   circleCss?: CSSObject;
   checked?: boolean;
-  defaultChecked?: boolean;
+  onCheckedChange: ({ checked }: { checked: boolean }) => void;
 }
 
-const Switch = forwardRef<HTMLInputElement, SwitchProps>(({
-  type = 'checkbox', wrapperCss, circleCss, checked, defaultChecked, ...rest
-}, ref) => {
+function Switch({
+  type = 'checkbox', wrapperCss, circleCss, checked, onCheckedChange, ...rest
+}: SwitchProps) {
   const inputIdRef = useRef(generateRandomId());
-  const { handleClick } = useSwitchHandler({ inputId: inputIdRef.current });
+  const [isChecked, setIsChecked] = useState(!!checked);
+  const { handleClick } = useSwitchHandler(
+    {
+      inputId: inputIdRef.current, onCheckedChange, isChecked, setIsChecked,
+    },
+  );
   const { switchWrapperStyle, switchCircleStyle, switchInputStyle } = useSwitchStyle();
-  const isChecked = checked || defaultChecked;
 
   // TODO: 하드코딩된 className 처리
   return (
     <div>
-      <input type={type} ref={ref} css={switchInputStyle} id={inputIdRef.current} className={isChecked ? 'switch-checked' : ''} {...rest} />
+      <input type={type} css={switchInputStyle} id={inputIdRef.current} className={isChecked ? 'switch-checked' : ''} {...rest} />
       <div css={[switchWrapperStyle, wrapperCss]} onClick={handleClick} role="presentation">
         <div css={[switchCircleStyle, circleCss]} />
       </div>
     </div>
   );
-});
+}
 
 export default Switch;

--- a/src/components/switch/switch.stories.tsx
+++ b/src/components/switch/switch.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Switch from '@components/switch';
 import { css } from '@emotion/react';
+import { useState } from 'react';
 
 const meta: Meta<typeof Switch> = {
   title: 'Components/Switch',
@@ -18,7 +19,7 @@ type Story = StoryObj<typeof Switch>;
 
 export const Default: Story = {
   args: {
-
+    onCheckedChange: ({ checked }) => console.log('checked', checked),
   },
 };
 
@@ -31,6 +32,24 @@ export const CustomStyled: Story = {
         }
       `
     ),
-    defaultChecked: true,
+    checked: true,
+    onCheckedChange: ({ checked }) => console.log('checked', checked),
+  },
+};
+
+export const Controlled: Story = {
+  args: {},
+  render: () => {
+    const [isChecked, setIsChecked] = useState(true);
+    console.log(`State outside: ${isChecked}`);
+    return (
+      <Switch
+        onCheckedChange={({ checked }) => {
+          setIsChecked(checked);
+          console.log(`Internal State: ${checked}`);
+        }}
+        checked={isChecked}
+      />
+    );
   },
 };

--- a/src/components/switch/useSwitchHandler.tsx
+++ b/src/components/switch/useSwitchHandler.tsx
@@ -1,16 +1,25 @@
+import { Dispatch, SetStateAction } from 'react';
+
 interface UseSwitchHandlerProps {
   inputId: string;
+  onCheckedChange: ({ checked }: { checked:boolean }) => void;
+  isChecked: boolean;
+  setIsChecked: Dispatch<SetStateAction<boolean>>;
 }
 
-function useSwitchHandler({ inputId }: UseSwitchHandlerProps) {
+function useSwitchHandler({
+  inputId, onCheckedChange, isChecked, setIsChecked,
+}: UseSwitchHandlerProps) {
   const handleClick = () => {
     if (!document || !inputId) return;
 
     const domInput = document.getElementById(inputId) as HTMLInputElement;
-    const checked = !domInput.checked;
-    domInput.checked = checked;
+    const nextCheckedStatus = !isChecked;
+    domInput.checked = nextCheckedStatus;
+    setIsChecked(nextCheckedStatus);
+    onCheckedChange({ checked: nextCheckedStatus });
 
-    if (checked) {
+    if (nextCheckedStatus) {
       domInput.classList.add('switch-checked');
 
       return;

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,18 +1,14 @@
-import { ElementType, ReactNode } from 'react';
+import { ElementType, HTMLAttributes, ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 
 export type FontWeight = 'regular' | 'medium' | 'bold' | 'lighter' | 'bolder';
 
-interface TextProps {
+interface TextProps extends HTMLAttributes<HTMLHeadingElement | HTMLParagraphElement> {
   children: ReactNode;
-  // eslint-disable-next-line react/no-unused-prop-types
   weight?: FontWeight;
-  // eslint-disable-next-line react/no-unused-prop-types
   as?: ElementType;
-  // eslint-disable-next-line react/no-unused-prop-types
   fontSize?: string;
-  // eslint-disable-next-line react/no-unused-prop-types
   color?: string;
 }
 
@@ -29,44 +25,46 @@ const Text = styled.p<TextProps>`
 
 export default Text;
 
-export function ErrorText({ children, variant = 'medium' }: VariantTextProps) {
+export function ErrorText({ children, variant = 'medium', ...rest }: VariantTextProps) {
   const theme = useTheme();
   const textSizes = {
     large: '16px', medium: '14px', small: '12px',
   };
-  return <Text as="p" fontSize={textSizes[variant]} color={theme.colors.other.error}>{children}</Text>;
+  return <Text as="p" fontSize={textSizes[variant]} color={theme.colors.other.error} {...rest}>{children}</Text>;
 }
 
-export function Paragraph({ children, variant = 'medium', weight }: VariantTextProps) {
+export function Paragraph({
+  children, variant = 'medium', weight, color, ...rest
+}: VariantTextProps) {
   const textSizes = {
     large: '18px', medium: '16px', small: '14px',
   };
-  return <Text as="p" fontSize={textSizes[variant]} weight={weight}>{children}</Text>;
+  return <Text as="p" fontSize={textSizes[variant]} weight={weight} color={color} {...rest}>{children}</Text>;
 }
 
 export const Heading = {
-  H1: ({ children, weight }: TextProps) => (
-    <Text as="h1" fontSize="32px" weight={weight}>
+  H1: ({ children, weight, ...rest }: TextProps) => (
+    <Text as="h1" fontSize="32px" weight={weight} {...rest}>
       {children}
     </Text>
   ),
-  H2: ({ children, weight }: TextProps) => (
-    <Text as="h2" fontSize="28px" weight={weight}>
+  H2: ({ children, weight, ...rest }: TextProps) => (
+    <Text as="h2" fontSize="28px" weight={weight} {...rest}>
       {children}
     </Text>
   ),
-  H3: ({ children, weight }: TextProps) => (
-    <Text as="h3" fontSize="24px" weight={weight}>
+  H3: ({ children, weight, ...rest }: TextProps) => (
+    <Text as="h3" fontSize="24px" weight={weight} {...rest}>
       {children}
     </Text>
   ),
-  H4: ({ children, weight }: TextProps) => (
-    <Text as="h4" fontSize="20px" weight={weight}>
+  H4: ({ children, weight, ...rest }: TextProps) => (
+    <Text as="h4" fontSize="20px" weight={weight} {...rest}>
       {children}
     </Text>
   ),
-  H5: ({ children, weight }: TextProps) => (
-    <Text as="h5" fontSize="18px" weight={weight}>
+  H5: ({ children, weight, ...rest }: TextProps) => (
+    <Text as="h5" fontSize="18px" weight={weight} {...rest}>
       {children}
     </Text>
   ),

--- a/src/components/textarea/index.tsx
+++ b/src/components/textarea/index.tsx
@@ -15,10 +15,12 @@ export interface TextareaProps extends HTMLAttributes<HTMLTextAreaElement> {
   cols?: number;
   maxLength?: number;
   resize?: 'vertical' | 'horizontal' | 'none' | 'both';
+  placeholder?: string;
 }
 
 const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
-  onChange, label, css, rows = 4, cols = 50, maxLength, resize = 'both', ...rest
+  onChange, label, css,
+  rows = 4, cols = 50, maxLength, resize = 'both', placeholder = '', ...rest
 }, ref) => {
   const textareaId = useRef(generateRandomId());
   const { textAreaStyle } = useTextAreaStyle({ resize });
@@ -42,6 +44,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextareaProps>(({
         maxLength={maxLength}
         ref={ref}
         onChange={onChange}
+        placeholder={placeholder}
         {...rest}
       />
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,6 +764,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hookform/error-message@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@hookform/error-message@npm:2.0.1"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    react-hook-form: ^7.0.0
+  checksum: 10c0/6b608bcdbd797ddb7c6cfc8c42b6bbac40066181a0c582b1f1a342bfa65fa7e8329cdb8e869a76e33988cd46fe8623d521ea597231b9d33e1f0ba3288e36c58e
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3015,6 +3026,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@eslint/js": "npm:^9.9.0"
+    "@hookform/error-message": "npm:^2.0.1"
     "@storybook/addon-essentials": "npm:8.3.6"
     "@storybook/addon-interactions": "npm:8.3.6"
     "@storybook/addon-links": "npm:8.3.6"
@@ -3042,6 +3054,7 @@ __metadata:
     globals: "npm:^15.9.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    react-hook-form: "npm:^7.53.2"
     reset-css: "npm:^5.0.2"
     storybook: "npm:8.3.6"
     typescript: "npm:^5.5.3"
@@ -6527,6 +6540,15 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 10c0/0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^7.53.2":
+  version: 7.53.2
+  resolution: "react-hook-form@npm:7.53.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10c0/18336d8e8798a70dcd0af703a0becca2d5dbf82a7b7a3ca334ae0e1f26410490bc3ef2ea51adcf790bb1e7006ed7a763fd00d664e398f71225b23529a7ccf0bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 변경점

- 다음 컴포넌트에 ref를 전달할 수 있도록 변경했습니다.
  - radio
  - checkbox
- textarea에 placeholder을 추가할 수 있도록 변경했습니다.
- text 및 grid, container에서 HTML attribute를 props로 전달할 수 있도록 변경했습니다.
- default padded container을 작성했습니다. 앞으로 메인 화면에서 컨텐츠 padding값을 통일할 때 사용할 예정입니다.
- grid와 container의 cssOverride prop을 다른 컴포넌트와 동일하게 `css`로 변경했습니다.
- fallback spinner(Suspense에서 사용)를 구현했습니다.
- progress bar을 구현했습니다 (by @harugi7)
- 새로 추가된 props나 props 변경점을 테스트하기 위해 스토리북 코드를 업데이트했습니다.
- 이제 Switch의 경우 폼에서 사용할 때 controlled 방식을 사용하도록 강제합니다.

## 기타

- react-hook-form을 추가했고 폼 에러메시지 관련 패키지를 추가했습니다. 따라서 본 pr이 머지된 후 `yarn install`을 실행하셔야 합니다.