### PR TITLE
CI/CD 워크플로 작성 (SCRUM-92)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,46 @@
+name: test/deploy
+on:
+  push:
+    branches: # 추후에 main, develop 배포 환경 분리
+      - main
+      - develop
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source code
+        uses: 'actions/checkout@v4'
+      - name: init yarn
+        uses: 'actions/setup-node@v4'
+        with:
+          node-version: '20'
+      - name: yarn berry setup
+        run: corepack enable && yarn set version berry
+      - name: install dependencies
+        run: yarn
+      - name: run eslint
+        run: yarn lint
+      - name: run vitest
+        run: yarn test:ci
+      - name: build
+        env:
+          VITE_BASE_URL: ${{ secrets.VITE_BASE_URL }}
+        run: yarn build
+      - name: Move files from dist to web root
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEPLOY_URL }}
+          username: ${{ secrets.DEPLOY_USERNAME }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: 22
+          script: |
+            rm -rf ${{ secrets.DEPLOY_WEBDIR }}/assets ${{ secrets.DEPLOY_WEBDIR }}/index.html
+      - name: Copy files to Lightsail
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.DEPLOY_URL }}
+          username: ${{ secrets.DEPLOY_USERNAME }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: 22
+          source: "dist/*"
+          target: ${{ secrets.DEPLOY_WEBDIR }}/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: ci
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - 'develop/**'
       - 'feature/**'
+      - 'main'
 jobs:
   init:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## #️⃣ 연관된 이슈
SCRUM-92, #14

## 📝 작업 내용
CI/CD를 자동화했습니다. 추후에 프로덕션 서버와 데브서버가 분리될 경우 워크플로를 소폭 수정해야 합니다.

### 워크플로

- main, develop 브랜치에 push 시 테스트 및 빌드, 서버에 배포를 수행합니다.
- main, develop, feature 브랜치에 PR 생성 시 코드 컨벤션 확인, 단위/통합 테스트 및 빌드 테스트를 수행합니다.