### PR TITLE
사냥 후 페이지 (AH-01, AH-02, AH-03) 구현 (SCRUM-105, 106, 107)

### DIFF
--- a/src/components/bottomSheet/handleBottomSheetProps.ts
+++ b/src/components/bottomSheet/handleBottomSheetProps.ts
@@ -1,0 +1,4 @@
+export interface HandleBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -11,7 +11,7 @@ function Navbar() {
   const theme = useTheme();
 
   const textStyle = css`
-      color: ${theme.colors.primary.darken};
+      color: ${theme.colors.primary.main};
       text-align: center;
       font-size: 12px;
       font-weight: bold;

--- a/src/features/afterHunting/DealEndBottomSheet.stories.tsx
+++ b/src/features/afterHunting/DealEndBottomSheet.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import DealEndBottomSheet from '@features/afterHunting/DealEndBottomSheet';
+import { MemoryRouter } from 'react-router-dom';
+
+type Story = StoryObj<BottomSheetProps>;
+
+export default {
+  title: 'Features/DealEndBottomSheet',
+  argTypes: {
+    isOpen: { control: 'boolean', defaultValue: false },
+  },
+} as Meta;
+
+interface BottomSheetProps {
+  isOpen: boolean;
+  toggleText: string;
+  Component: React.FC<{ isOpen: boolean; onClose: () => void }>;
+}
+
+function BottomSheetTemplate({
+  isOpen: initialIsOpen,
+  toggleText,
+  Component,
+}: BottomSheetProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(initialIsOpen);
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <MemoryRouter>
+      <button type="button" onClick={handleToggle}>
+        {toggleText}
+      </button>
+      <Component isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </MemoryRouter>
+  );
+}
+
+export const DealEndBottomSheetStory: Story = {
+  render: (args) => <BottomSheetTemplate {...args} />,
+};
+DealEndBottomSheetStory.args = {
+  isOpen: false,
+  toggleText: 'Open Hunt End Bottom Sheet',
+  Component: DealEndBottomSheet,
+};

--- a/src/features/afterHunting/DealEndBottomSheet.tsx
+++ b/src/features/afterHunting/DealEndBottomSheet.tsx
@@ -1,0 +1,39 @@
+import Button from '@components/button';
+import BottomSheet from '@components/bottomSheet';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+import { useNavigate } from 'react-router-dom';
+import { HandleBottomSheetProps } from '@components/bottomSheet/handleBottomSheetProps';
+
+function DealEndBottomSheet({ isOpen, onClose }: HandleBottomSheetProps) {
+  const navigate = useNavigate();
+
+  const handleEndDeal = () => {
+    navigate('/');
+  };
+
+  return (
+    <BottomSheet isOpen={isOpen} onChange={onClose}>
+      <Container
+        direction="column"
+        align="flex-start"
+        gap="15px"
+      >
+        <Heading.H3_5 weight="semi-bold">거래와 함께 퀵챗을 종료할게요</Heading.H3_5>
+        <Container
+          direction="column"
+          align="flex-start"
+          gap="6px"
+        >
+          <Paragraph>채팅은 강제 종료되고</Paragraph>
+          <Paragraph>다시 접근할 수 없습니다</Paragraph>
+          <Container justify="space-between" gap="14px" css={{ marginTop: '34px' }}>
+            <Button onClick={handleEndDeal}>거래 마치기</Button>
+          </Container>
+        </Container>
+      </Container>
+    </BottomSheet>
+  );
+}
+
+export default DealEndBottomSheet;

--- a/src/features/afterHunting/HuntEndBottomSheet.stories.tsx
+++ b/src/features/afterHunting/HuntEndBottomSheet.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import HuntEndBottomSheet from '@features/afterHunting/HuntEndBottomSheet';
+import { MemoryRouter } from 'react-router-dom';
+
+type Story = StoryObj<BottomSheetProps>;
+
+export default {
+  title: 'Features/HuntEndBottomSheet',
+  argTypes: {
+    isOpen: { control: 'boolean', defaultValue: false },
+  },
+} as Meta;
+
+interface BottomSheetProps {
+  isOpen: boolean;
+  toggleText: string;
+  Component: React.FC<{ isOpen: boolean; onClose: () => void }>;
+}
+
+function BottomSheetTemplate({
+  isOpen: initialIsOpen,
+  toggleText,
+  Component,
+}: BottomSheetProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(initialIsOpen);
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <MemoryRouter>
+      <button type="button" onClick={handleToggle}>
+        {toggleText}
+      </button>
+      <Component isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </MemoryRouter>
+  );
+}
+
+export const HuntEndBottomSheetStory: Story = {
+  render: (args) => <BottomSheetTemplate {...args} />,
+};
+HuntEndBottomSheetStory.args = {
+  isOpen: false,
+  toggleText: 'Open Hunt End Bottom Sheet',
+  Component: HuntEndBottomSheet,
+};

--- a/src/features/afterHunting/HuntEndBottomSheet.tsx
+++ b/src/features/afterHunting/HuntEndBottomSheet.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+import Button from '@components/button';
+import BottomSheet from '@components/bottomSheet';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+import useBottomSheetBtnStyle from '@components/bottomSheet/useBottomSheetBtnStyle';
+import { useNavigate } from 'react-router-dom';
+
+interface HuntEndBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
+  const {
+    btnStyle,
+    cancelBtnStyle,
+  } = useBottomSheetBtnStyle();
+
+  const headingStyle = css`
+      font-size: 22px;
+  `;
+
+  const navigate = useNavigate();
+
+  const handleStartDeal = () => {
+    navigate('/');
+  };
+
+  return (
+    <BottomSheet isOpen={isOpen} onChange={onClose}>
+      <Container
+        direction="column"
+        align="flex-start"
+        gap="15px"
+      >
+        <Heading.H4 weight="semi-bold" css={headingStyle}>사냥이 끝났나요?</Heading.H4>
+        <Container
+          direction="column"
+          align="flex-start"
+          gap="6px"
+        >
+          <Paragraph>사냥 후에는 서비스의 안내에 따라</Paragraph>
+          <Paragraph>대면 거래를 진행할 수 있어요</Paragraph>
+          <Container justify="space-between" gap="14px">
+            <Button css={cancelBtnStyle} onClick={onClose}>아직이요</Button>
+            <Button css={btnStyle} variant="primary" onClick={handleStartDeal}>거래하기</Button>
+          </Container>
+        </Container>
+      </Container>
+    </BottomSheet>
+  );
+}
+
+export default HuntEndBottomSheet;

--- a/src/features/afterHunting/HuntEndBottomSheet.tsx
+++ b/src/features/afterHunting/HuntEndBottomSheet.tsx
@@ -3,13 +3,9 @@ import BottomSheet from '@components/bottomSheet';
 import Container from '@components/container';
 import { Heading, Paragraph } from '@components/text';
 import { useNavigate } from 'react-router-dom';
+import { HandleBottomSheetProps } from '@components/bottomSheet/handleBottomSheetProps';
 
-interface HuntEndBottomSheetProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
+function HuntEndBottomSheet({ isOpen, onClose }: HandleBottomSheetProps) {
   const navigate = useNavigate();
 
   const handleStartDeal = () => {

--- a/src/features/afterHunting/HuntEndBottomSheet.tsx
+++ b/src/features/afterHunting/HuntEndBottomSheet.tsx
@@ -2,7 +2,6 @@ import Button from '@components/button';
 import BottomSheet from '@components/bottomSheet';
 import Container from '@components/container';
 import { Heading, Paragraph } from '@components/text';
-import useBottomSheetBtnStyle from '@components/bottomSheet/useBottomSheetBtnStyle';
 import { useNavigate } from 'react-router-dom';
 
 interface HuntEndBottomSheetProps {
@@ -11,11 +10,6 @@ interface HuntEndBottomSheetProps {
 }
 
 function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
-  const {
-    btnStyle,
-    cancelBtnStyle,
-  } = useBottomSheetBtnStyle();
-
   const navigate = useNavigate();
 
   const handleStartDeal = () => {
@@ -37,9 +31,9 @@ function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
         >
           <Paragraph>사냥 후에는 서비스의 안내에 따라</Paragraph>
           <Paragraph>대면 거래를 진행할 수 있어요</Paragraph>
-          <Container justify="space-between" gap="14px">
-            <Button css={cancelBtnStyle} onClick={onClose}>아직이요</Button>
-            <Button css={btnStyle} variant="primary" onClick={handleStartDeal}>거래하기</Button>
+          <Container justify="space-between" gap="14px" css={{ marginTop: '34px' }}>
+            <Button variant="secondary" onClick={onClose}>아직이요</Button>
+            <Button onClick={handleStartDeal}>거래하기</Button>
           </Container>
         </Container>
       </Container>

--- a/src/features/afterHunting/HuntEndBottomSheet.tsx
+++ b/src/features/afterHunting/HuntEndBottomSheet.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import Button from '@components/button';
 import BottomSheet from '@components/bottomSheet';
 import Container from '@components/container';
@@ -17,10 +16,6 @@ function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
     cancelBtnStyle,
   } = useBottomSheetBtnStyle();
 
-  const headingStyle = css`
-      font-size: 22px;
-  `;
-
   const navigate = useNavigate();
 
   const handleStartDeal = () => {
@@ -34,7 +29,7 @@ function HuntEndBottomSheet({ isOpen, onClose }: HuntEndBottomSheetProps) {
         align="flex-start"
         gap="15px"
       >
-        <Heading.H4 weight="semi-bold" css={headingStyle}>사냥이 끝났나요?</Heading.H4>
+        <Heading.H3_5 weight="semi-bold">사냥이 끝났나요?</Heading.H3_5>
         <Container
           direction="column"
           align="flex-start"

--- a/src/mock/bug-report/index.ts
+++ b/src/mock/bug-report/index.ts
@@ -1,0 +1,18 @@
+import logo from '@assets/icons/x.svg';
+import { BugReport } from '@/types/bug-report';
+
+const mockBugReport: BugReport = {
+  id: 1,
+  latitude: 37.7749,
+  longitude: -122.4194,
+  user_id: 101,
+  bug_image_url: logo,
+  bug_type: '개미',
+  bug_size: '작음',
+  equipment: '살충제',
+  price: 5000,
+  note: '화장실에서 나왔어요.',
+  title: '화장실에서 개미가 나왔어요.',
+};
+
+export default mockBugReport;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,32 +1,23 @@
-import { useEffect } from 'react';
-import { useCurrentUser } from '@providers/CurrentUserProvider';
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Header from '@components/header';
+import RequestHelpBanner from '@features/main/banner/RequestHelpBanner';
+import CatchRequestList from '@features/main/CatchRequestList';
+import Navbar from '@components/navbar';
+import Container from '@components/container';
+import Spacing from '@components/spacing';
 
 function MainPage() {
-  const { isLoggedIn, currentUser } = useCurrentUser();
-
-  useEffect(() => {
-    console.log('isLoggedIn:', isLoggedIn);
-    console.log('currentUser:', currentUser);
-  }, [isLoggedIn, currentUser]);
-
   return (
-    <div>
-      {isLoggedIn ? (
-        <div>
-          <p>로그인되었습니다!</p>
-          <p>
-            이름:
-            {currentUser?.name}
-          </p>
-          <p>
-            이메일:
-            {currentUser?.email}
-          </p>
-        </div>
-      ) : (
-        <p>로그인되지 않았습니다.</p>
-      )}
-    </div>
+    <DefaultPaddedContainer>
+      <Container direction="column" padding="0 0 100px 0">
+        <Header />
+        <Spacing height="3  px" />
+        <RequestHelpBanner />
+        <Spacing height="30px" />
+        <CatchRequestList />
+        <Navbar />
+      </Container>
+    </DefaultPaddedContainer>
   );
 }
 

--- a/src/pages/afterHunting/DealProcessPage.stories.tsx
+++ b/src/pages/afterHunting/DealProcessPage.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import DealProcessPage from '@pages/afterHunting/DealProcessPage';
+import { MemoryRouter } from 'react-router-dom';
+
+const meta: Meta<typeof DealProcessPage> = {
+  title: 'Pages/AfterHunt/DealProcessPage',
+  component: DealProcessPage,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DealProcessPage>;
+
+export const DealProcessPageDefault: Story = {
+  args: {},
+};

--- a/src/pages/afterHunting/DealProcessPage.tsx
+++ b/src/pages/afterHunting/DealProcessPage.tsx
@@ -37,10 +37,10 @@ function DealProcessPage() {
     <DefaultPaddedContainer>
       <Container direction="column" css={headingStyle}>
         <Container>
-          <Heading.H4 weight="semi-bold">계좌이체</Heading.H4>
+          <Heading.H3_5 weight="semi-bold">계좌이체</Heading.H3_5>
           나
           <div style={{ width: '8px' }} />
-          <Heading.H4 weight="semi-bold">현금</Heading.H4>
+          <Heading.H3_5 weight="semi-bold">현금</Heading.H3_5>
           으로
         </Container>
         <div>거래를 진행해주세요</div>

--- a/src/pages/afterHunting/DealProcessPage.tsx
+++ b/src/pages/afterHunting/DealProcessPage.tsx
@@ -15,7 +15,6 @@ function DealProcessPage() {
     ulStyle,
     btnPositionStyle,
     explainStyle,
-    btnStyle,
   } = useDealProcessPageStyle();
 
   const [bugReportData, setBugReportData] = useState<BugReport>();
@@ -60,7 +59,7 @@ function DealProcessPage() {
       </Container>
       <Container css={btnPositionStyle}>
         <Paragraph css={explainStyle}>계좌이체의 경우 송금 내역을 확인 후 버튼을 눌러주세요.</Paragraph>
-        <Button variant="primary" css={btnStyle} onClick={handleNavigate}>완료했어요</Button>
+        <Button onClick={handleNavigate}>완료했어요</Button>
       </Container>
     </DefaultPaddedContainer>
   );

--- a/src/pages/afterHunting/DealProcessPage.tsx
+++ b/src/pages/afterHunting/DealProcessPage.tsx
@@ -1,0 +1,69 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Button from '@components/button';
+import { Heading, Paragraph } from '@components/text';
+import Container from '@components/container';
+import useDealProcessPageStyle from '@pages/afterHunting/useDealProcessPageStyle';
+import { useState, useEffect } from 'react';
+import mockBugReport from 'mock/bug-report';
+import { useNavigate } from 'react-router-dom';
+import { BugReport } from '@/types/bug-report';
+
+function DealProcessPage() {
+  const {
+    headingStyle,
+    priceStyle,
+    ulStyle,
+    btnPositionStyle,
+    explainStyle,
+    btnStyle,
+  } = useDealProcessPageStyle();
+
+  const [bugReportData, setBugReportData] = useState<BugReport>();
+
+  useEffect(() => {
+    setBugReportData(mockBugReport);
+  }, []);
+
+  const formatPrice = (price: number) => new Intl.NumberFormat('en-US').format(price);
+
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    // TODO: api 연결 후 조건에 따라 AH-03(대기페이지) 또는 AH-04로 이동
+    navigate('/');
+  };
+
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" css={headingStyle}>
+        <Container>
+          <Heading.H4 weight="semi-bold">계좌이체</Heading.H4>
+          나
+          <div style={{ width: '8px' }} />
+          <Heading.H4 weight="semi-bold">현금</Heading.H4>
+          으로
+        </Container>
+        <div>거래를 진행해주세요</div>
+      </Container>
+      <Container gap="22px" align="center" justify="center">
+        <Heading.H4>계약 금액</Heading.H4>
+        <Container css={priceStyle}>
+          {bugReportData ? formatPrice(bugReportData.price) : '0'}
+        </Container>
+      </Container>
+      <Container css={ulStyle}>
+        <ul style={{ listStyle: 'disc', paddingLeft: '20px' }}>
+          <li>상호 간 합의 하에 거래 금액을 변경할 수 있습니다.</li>
+          <li>헌터가 벌레를 잡지 못했을 때는 돈을 지불하지 않아도 됩니다.</li>
+          <li>헌터가 벌레를 빠르게, 잘 잡았을 경우 추가금을 제공할 수 있습니다.</li>
+        </ul>
+      </Container>
+      <Container css={btnPositionStyle}>
+        <Paragraph css={explainStyle}>계좌이체의 경우 송금 내역을 확인 후 버튼을 눌러주세요.</Paragraph>
+        <Button variant="primary" css={btnStyle} onClick={handleNavigate}>완료했어요</Button>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+
+export default DealProcessPage;

--- a/src/pages/afterHunting/DealProcessPage.tsx
+++ b/src/pages/afterHunting/DealProcessPage.tsx
@@ -2,7 +2,7 @@ import { DefaultPaddedContainer } from '@components/container/variants';
 import Button from '@components/button';
 import { Heading, Paragraph } from '@components/text';
 import Container from '@components/container';
-import useDealProcessPageStyle from '@pages/afterHunting/useDealProcessPageStyle';
+import useAfterHuntingPageStyle from '@pages/afterHunting/useAfterHuntingPageStyle';
 import { useState, useEffect } from 'react';
 import mockBugReport from 'mock/bug-report';
 import { useNavigate } from 'react-router-dom';
@@ -15,7 +15,7 @@ function DealProcessPage() {
     ulStyle,
     btnPositionStyle,
     explainStyle,
-  } = useDealProcessPageStyle();
+  } = useAfterHuntingPageStyle();
 
   const [bugReportData, setBugReportData] = useState<BugReport>();
 
@@ -36,13 +36,12 @@ function DealProcessPage() {
     <DefaultPaddedContainer>
       <Container direction="column" css={headingStyle}>
         <Container>
-          <Heading.H3_5 weight="semi-bold">계좌이체</Heading.H3_5>
-          나
-          <div style={{ width: '8px' }} />
-          <Heading.H3_5 weight="semi-bold">현금</Heading.H3_5>
-          으로
+          <Heading.H3_5 weight="semi-bold">계좌이체나 현금</Heading.H3_5>
+          <Heading.H3_5>으로</Heading.H3_5>
         </Container>
-        <div>거래를 진행해주세요</div>
+        <Container>
+          <Heading.H3_5>거래를 진행해주세요</Heading.H3_5>
+        </Container>
       </Container>
       <Container gap="22px" align="center" justify="center">
         <Heading.H4>계약 금액</Heading.H4>

--- a/src/pages/afterHunting/DealWaitingPage.stories.tsx
+++ b/src/pages/afterHunting/DealWaitingPage.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import DealWaitingPage from '@pages/afterHunting/DealWaitingPage';
+import { MemoryRouter } from 'react-router-dom';
+
+const meta: Meta<typeof DealWaitingPage> = {
+  title: 'Pages/AfterHunt/DealWaitingPage',
+  component: DealWaitingPage,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DealWaitingPage>;
+
+export const DealWaitingPageDefault: Story = {
+  args: {},
+};

--- a/src/pages/afterHunting/DealWaitingPage.tsx
+++ b/src/pages/afterHunting/DealWaitingPage.tsx
@@ -1,0 +1,46 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Button from '@components/button';
+import { Heading } from '@components/text';
+import Container from '@components/container';
+import useDealProcessPageStyle from '@pages/afterHunting/useDealProcessPageStyle';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function DealWaitingPage() {
+  const {
+    headingStyle,
+    btnPositionStyle,
+  } = useDealProcessPageStyle();
+
+  const navigate = useNavigate();
+
+  const [status, setStatus] = useState<boolean>(false);
+
+  const handleNavigate = () => {
+    // TODO: 후기 페이지로 이동
+    navigate('/');
+  };
+
+  useEffect(() => {
+    // TODO: api로 거래 완료 상태 받아와서 처리
+    const changeStatus = () => {
+      setTimeout(() => { setStatus(true); }, 3000);
+    };
+
+    changeStatus();
+  }, []);
+
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" css={headingStyle}>
+        <Heading.H3_5 weight="semi-bold">상대방의 완료 여부를</Heading.H3_5>
+        <Heading.H3_5 weight="semi-bold">기다리고 있어요</Heading.H3_5>
+      </Container>
+      <Container css={btnPositionStyle}>
+        <Button variant={status ? 'default' : 'secondary'} onClick={handleNavigate}>완료했어요</Button>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+
+export default DealWaitingPage;

--- a/src/pages/afterHunting/DealWaitingPage.tsx
+++ b/src/pages/afterHunting/DealWaitingPage.tsx
@@ -2,7 +2,7 @@ import { DefaultPaddedContainer } from '@components/container/variants';
 import Button from '@components/button';
 import { Heading } from '@components/text';
 import Container from '@components/container';
-import useDealProcessPageStyle from '@pages/afterHunting/useDealProcessPageStyle';
+import useAfterHuntingPageStyle from '@pages/afterHunting/useAfterHuntingPageStyle';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,7 +10,7 @@ function DealWaitingPage() {
   const {
     headingStyle,
     btnPositionStyle,
-  } = useDealProcessPageStyle();
+  } = useAfterHuntingPageStyle();
 
   const navigate = useNavigate();
 

--- a/src/pages/afterHunting/TempChatPage.stories.tsx
+++ b/src/pages/afterHunting/TempChatPage.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from '@storybook/react';
+import TempChatPage from '@pages/afterHunting/TempChatPage';
+import { MemoryRouter } from 'react-router-dom';
+
+const meta: Meta<typeof TempChatPage> = {
+  title: 'Pages/AfterHunt/TempChatPage',
+  component: TempChatPage,
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TempChatPage>;
+
+export const TempChatPageDefault: Story = {
+  args: { },
+};

--- a/src/pages/afterHunting/TempChatPage.stories.tsx
+++ b/src/pages/afterHunting/TempChatPage.stories.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 const meta: Meta<typeof TempChatPage> = {
   title: 'Pages/AfterHunt/TempChatPage',
   component: TempChatPage,
+  parameters: { layout: 'fullscreen' },
   decorators: [
     (Story) => (
       <MemoryRouter initialEntries={['/']}>

--- a/src/pages/afterHunting/TempChatPage.tsx
+++ b/src/pages/afterHunting/TempChatPage.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Button from '@components/button';
+import HuntEndBottomSheet from '@features/afterHunting/HuntEndBottomSheet';
+
+function TempChatPage() {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState<boolean>(false);
+
+  const handleOpenBottomSheet = () => {
+    setIsBottomSheetOpen(true);
+  };
+
+  const handleCloseBottomSheet = () => {
+    setIsBottomSheetOpen(false);
+  };
+
+  return (
+    <DefaultPaddedContainer>
+      <Button onClick={handleOpenBottomSheet}>사냥 종료하기</Button>
+      <HuntEndBottomSheet isOpen={isBottomSheetOpen} onClose={handleCloseBottomSheet} />
+    </DefaultPaddedContainer>
+  );
+}
+
+export default TempChatPage;

--- a/src/pages/afterHunting/useAfterHuntingPageStyle.ts
+++ b/src/pages/afterHunting/useAfterHuntingPageStyle.ts
@@ -1,11 +1,10 @@
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 
-function useBugInputPageStyle() {
+function useAfterHuntingPageStyle() {
+  const theme = useTheme();
+
   const headingStyle = css`
-      display: block;
-      font-size: 22px;
       line-height: 30px;
-      letter-spacing: -0.32px;
       margin-top: 96px;
       margin-bottom: 37px;
   `;
@@ -15,9 +14,6 @@ function useBugInputPageStyle() {
       width: 110px;
       height: 40px;
       font-size: 20px;
-      font-weight: 400;
-      line-height: 26px;
-      letter-spacing: -0.32px;
       text-align: right;
       padding: 7px;
       border-radius: 8px;
@@ -28,8 +24,7 @@ function useBugInputPageStyle() {
       font-size: 12px;
       font-weight: 400;
       line-height: 16px;
-      letter-spacing: -0.32px;
-      color: #9B9B9B;
+      color: ${theme.colors.text.explain_gray};
       margin-top: 25px;
   `;
 
@@ -37,11 +32,11 @@ function useBugInputPageStyle() {
       display: block;
       position: fixed;
       bottom: 10px;
-      padding: 0px 20px;
+      padding: 0 20px;
       left: 0;
-      right: 0; /* 옵션: 요소를 화면의 전체 너비로 고정 */
-      width: 100%; /* 필요에 따라 너비를 조정 */
-      text-align: center; /* 텍스트나 내용 정렬 */
+      right: 0;
+      width: 100%;
+      text-align: center;
   `;
 
   const explainStyle = css`
@@ -50,7 +45,7 @@ function useBugInputPageStyle() {
       line-height: 16px;
       letter-spacing: -0.32px;
       margin-bottom: 12px;
-      color: #9B9B9B;
+      color: ${theme.colors.text.explain_gray};
   `;
 
   return {
@@ -62,4 +57,4 @@ function useBugInputPageStyle() {
   };
 }
 
-export default useBugInputPageStyle;
+export default useAfterHuntingPageStyle;

--- a/src/pages/afterHunting/useDealProcessPageStyle.ts
+++ b/src/pages/afterHunting/useDealProcessPageStyle.ts
@@ -1,0 +1,74 @@
+import { css } from '@emotion/react';
+
+function useBugInputPageStyle() {
+  const headingStyle = css`
+      display: block;
+      font-size: 20px;
+      line-height: 27px;
+      letter-spacing: -0.32px;
+      margin-top: 96px;
+      margin-bottom: 37px;
+  `;
+
+  const priceStyle = css`
+      display: block;
+      width: 110px;
+      height: 40px;
+      font-size: 20px;
+      font-weight: 400;
+      line-height: 26px;
+      letter-spacing: -0.32px;
+      text-align: right;
+      padding: 7px;
+      border-radius: 8px;
+      background-color: #F2F3F6;
+  `;
+
+  const ulStyle = css`
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 16px;
+      letter-spacing: -0.32px;
+      color: #9B9B9B;
+      margin-top: 25px;
+  `;
+
+  const btnPositionStyle = css`
+      display: block;
+      position: fixed;
+      bottom: 10px;
+      padding: 0px 20px;
+      left: 0;
+      right: 0; /* 옵션: 요소를 화면의 전체 너비로 고정 */
+      width: 100%; /* 필요에 따라 너비를 조정 */
+      text-align: center; /* 텍스트나 내용 정렬 */
+  `;
+
+  const explainStyle = css`
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 16px;
+      letter-spacing: -0.32px;
+      color: #9B9B9B;
+  `;
+
+  const btnStyle = css`
+      width: 100%;
+      height: 50px;
+      margin-top: 12px;
+      margin-bottom: 23px;
+      font-size: 16px;
+      border-radius: 8px;
+  `;
+
+  return {
+    headingStyle,
+    priceStyle,
+    ulStyle,
+    btnPositionStyle,
+    explainStyle,
+    btnStyle,
+  };
+}
+
+export default useBugInputPageStyle;

--- a/src/pages/afterHunting/useDealProcessPageStyle.ts
+++ b/src/pages/afterHunting/useDealProcessPageStyle.ts
@@ -4,7 +4,7 @@ function useBugInputPageStyle() {
   const headingStyle = css`
       display: block;
       font-size: 22px;
-      line-height: 27px;
+      line-height: 30px;
       letter-spacing: -0.32px;
       margin-top: 96px;
       margin-bottom: 37px;
@@ -49,16 +49,8 @@ function useBugInputPageStyle() {
       font-weight: 400;
       line-height: 16px;
       letter-spacing: -0.32px;
+      margin-bottom: 12px;
       color: #9B9B9B;
-  `;
-
-  const btnStyle = css`
-      width: 100%;
-      height: 50px;
-      margin-top: 12px;
-      margin-bottom: 23px;
-      font-size: 16px;
-      border-radius: 8px;
   `;
 
   return {
@@ -67,7 +59,6 @@ function useBugInputPageStyle() {
     ulStyle,
     btnPositionStyle,
     explainStyle,
-    btnStyle,
   };
 }
 

--- a/src/pages/afterHunting/useDealProcessPageStyle.ts
+++ b/src/pages/afterHunting/useDealProcessPageStyle.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 function useBugInputPageStyle() {
   const headingStyle = css`
       display: block;
-      font-size: 20px;
+      font-size: 22px;
       line-height: 27px;
       letter-spacing: -0.32px;
       margin-top: 96px;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -25,6 +25,7 @@ function LoginPage() {
             css={{
               height: '50px',
               width: '100%',
+              color: 'black',
               borderRadius: '8px',
               backgroundColor: '#FEE500',
               fontSize: '18px',

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -12,6 +12,7 @@ const colorTheme: Colors = {
     moderate: '#71787F',
     subtle: '#B2B6BB',
     darken_white: '#F7FAFE',
+    explain_gray: '#9B9B9B',
   },
   background: {
     main: '#FFFFFF',

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -17,6 +17,7 @@ export type Colors = {
     moderate: string;
     subtle: string;
     darken_white: string;
+    explain_gray: string;
   };
   background: {
     main: string;

--- a/src/types/bug-report/index.d.ts
+++ b/src/types/bug-report/index.d.ts
@@ -1,0 +1,17 @@
+export interface BugReport {
+  id: number;
+  latitude: number;
+  longitude: number;
+  user_id: number;
+  bug_image_url?: string | null;
+  bug_type?: string | null;
+  bug_size?: string | null;
+  equipment?: string | null;
+  price: number;
+  note?: string | null;
+  // created_at: Date;
+  // status: BugReportStatus;
+  title: string;
+  // user: User;
+  // matches: Match[];
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
사냥 후 페이지(After Hunting, AH-01, AH-02, AH-03) 구현 #21

## 📝 작업 내용
- AH-01, 임시 채팅창에서 버튼을 누를시 바텀시트로 연결
- AH-02, 계좌이체 및 현금거래 대기 페이지 구현
- AH-03, 먼저 '완료했어요' 버튼을 누른 사용자가 대기하는 페이지

### 스크린샷
![AH-01](https://github.com/user-attachments/assets/f74d8547-da13-4ed1-9ca1-f408048bae9a)
![AH-02](https://github.com/user-attachments/assets/74c6a88d-08a9-4d59-bc91-df27c5de2eff)
![AH-03](https://github.com/user-attachments/assets/9f62e2fd-71d9-4f3a-8193-b5c2d16ed380)

