### PR TITLE
헌터 매칭 과정에 필요한 페이지 및 바텀시트 구현 (SCRUM-86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",
     "react-router-dom": "^7.0.1",
-    "reset-css": "^5.0.2"
+    "react-slick": "^0.30.3",
+    "reset-css": "^5.0.2",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "1.9.0",
@@ -40,6 +42,8 @@
     "@types/eslint-plugin-jsx-a11y": "^6",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-slick": "^0",
+    "@types/slick-carousel": "^1",
     "@typescript-eslint/eslint-plugin": "7.0.0",
     "@typescript-eslint/parser": "^8.7.0",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/src/assets/icons/arrow-back.svg
+++ b/src/assets/icons/arrow-back.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.6154 15L18.2501 21.6347L19.1348 20.75L13.3848 15L19.1348 9.25002L18.2501 8.36533L11.6154 15Z" fill="black" stroke="black" stroke-width="0.5"/>
+</svg>

--- a/src/components/button/useButtonStyle.ts
+++ b/src/components/button/useButtonStyle.ts
@@ -10,7 +10,7 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
 
   const variantStyles = {
     default: {
-      fontSize: '18px',
+      fontSize: '16px',
       height: '50px',
       padding: '0',
       backgroundColor: globalTheme.colors.primary.main,
@@ -38,7 +38,7 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
       disabledColor: globalTheme.colors.text.subtle,
     },
     secondary: {
-      fontSize: '18px',
+      fontSize: '16px',
       height: '50px',
       padding: '0',
       backgroundColor: globalTheme.colors.primary.lighten,

--- a/src/components/button/useButtonStyle.ts
+++ b/src/components/button/useButtonStyle.ts
@@ -25,14 +25,14 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
     },
     select: {
       fontSize: '14px',
-      height: '21px',
-      padding: '4px 15px',
+      height: 'auto',
+      padding: '5px 15px',
       backgroundColor: globalTheme.colors.background.main,
       color: globalTheme.colors.primary.main,
       border: `0.5px solid ${globalTheme.colors.primary.main}`,
       borderRadius: '100px',
-      hoverBackgroundColor: globalTheme.colors.background.darken,
-      hoverColor: globalTheme.colors.text.prominent,
+      hoverBackgroundColor: globalTheme.colors.primary.main,
+      hoverColor: 'white',
       hoverBorderColor: globalTheme.colors.border.prominent,
       disabledBackgroundColor: globalTheme.colors.background.darken,
       disabledColor: globalTheme.colors.text.subtle,
@@ -73,6 +73,7 @@ function useButtonStyle({ variant = 'default' }: UseButtonStyleProps) {
     gap: 5px;
     
     &:hover {
+      width: 100%;
       background-color: ${styles.hoverBackgroundColor};
       color: ${styles.hoverColor};
       border: 1px solid ${styles.hoverBorderColor};

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -13,7 +13,7 @@ interface TextProps extends HTMLAttributes<HTMLHeadingElement | HTMLParagraphEle
 }
 
 interface VariantTextProps extends TextProps {
-  variant?: 'large' | 'medium' | 'small';
+  variant?: 'large' | 'medium' | 'small' | 'xsmall';
 }
 
 const Text = styled.p<TextProps>`
@@ -45,7 +45,7 @@ export default Text;
 export function ErrorText({ children, variant = 'medium', ...rest }: VariantTextProps) {
   const theme = useTheme();
   const textSizes = {
-    large: '16px', medium: '14px', small: '12px',
+    large: '16px', medium: '14px', small: '12px', xsmall: '10px',
   };
   return <Text as="p" fontSize={textSizes[variant]} color={theme.colors.other.error} {...rest}>{children}</Text>;
 }
@@ -54,7 +54,7 @@ export function Paragraph({
   children, variant = 'medium', weight, color, ...rest
 }: VariantTextProps) {
   const textSizes = {
-    large: '18px', medium: '16px', small: '14px',
+    large: '18px', medium: '16px', small: '14px', xsmall: '12px',
   };
   return <Text as="p" fontSize={textSizes[variant]} weight={weight} color={color} {...rest}>{children}</Text>;
 }

--- a/src/features/hunterMatching/ConfirmCancelMatchingBottomSheet.tsx
+++ b/src/features/hunterMatching/ConfirmCancelMatchingBottomSheet.tsx
@@ -1,0 +1,37 @@
+import Button from '@components/button';
+import BottomSheet from '@components/bottomSheet';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+
+interface ConfirmCancelMatchingBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function ConfirmCancelMatchingBottomSheet({
+  isOpen,
+  onClose,
+}: ConfirmCancelMatchingBottomSheetProps) {
+  return (
+    <BottomSheet isOpen={isOpen} onChange={onClose}>
+      <Container
+        direction="column"
+        justify="flex-start"
+        align="flex-start"
+        gap="15px"
+      >
+        <Heading.H3_5 weight="bold">헌터 매칭을 취소하시겠어요?</Heading.H3_5>
+        <Container direction="column" padding="0 0 19px 0" gap="5px">
+          <Paragraph variant="medium" weight="regular">이후에도 다른 헌터의 요청을 받을 수 있지만</Paragraph>
+          <Paragraph variant="medium" weight="regular">시간이 더 걸릴 수 있어요</Paragraph>
+        </Container>
+        <Container gap="14px">
+          <Button variant="secondary">매칭 돌아가기</Button>
+          <Button>취소하기</Button>
+        </Container>
+      </Container>
+    </BottomSheet>
+  );
+}
+
+export default ConfirmCancelMatchingBottomSheet;

--- a/src/features/hunterMatching/HunterMatchingBottomSheet.stories.tsx
+++ b/src/features/hunterMatching/HunterMatchingBottomSheet.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import MoveToQuickChatBottomSheet from '@features/hunterMatching/MoveToQuickChatBottomSheet';
+import ConfirmCancelMatchingBottomSheet from '@features/hunterMatching/ConfirmCancelMatchingBottomSheet';
 
 type Story = StoryObj<BottomSheetProps>;
 
@@ -45,11 +46,11 @@ MoveToQuickChatBottomSheetStory.args = {
   Component: MoveToQuickChatBottomSheet,
 };
 
-// export const CameraRequestBottomSheetStory: Story = {
-//   render: (args) => <BottomSheetTemplate {...args} />,
-// };
-// CameraRequestBottomSheetStory.args = {
-//   isOpen: false,
-//   toggleText: 'Toggle Camera Request Bottom Sheet',
-//   Component: CameraRequestBottomSheet,
-// };
+export const ConfirmCancelMatchingBottomSheetStory: Story = {
+  render: (args) => <BottomSheetTemplate {...args} />,
+};
+ConfirmCancelMatchingBottomSheetStory.args = {
+  isOpen: false,
+  toggleText: 'Toggle Camera Request Bottom Sheet',
+  Component: ConfirmCancelMatchingBottomSheet,
+};

--- a/src/features/hunterMatching/MoveToQuickChatBottomSheet.stories.tsx
+++ b/src/features/hunterMatching/MoveToQuickChatBottomSheet.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import MoveToQuickChatBottomSheet from '@features/hunterMatching/MoveToQuickChatBottomSheet';
+
+type Story = StoryObj<BottomSheetProps>;
+
+export default {
+  title: 'Features/HunterMatchingBottomSheet',
+  argTypes: {
+    isOpen: { control: 'boolean', defaultValue: false },
+  },
+} as Meta;
+
+interface BottomSheetProps {
+  isOpen: boolean;
+  toggleText: string;
+  Component: React.FC<{ isOpen: boolean; onClose: () => void }>;
+}
+
+function BottomSheetTemplate({
+  isOpen: initialIsOpen,
+  toggleText,
+  Component,
+}: BottomSheetProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(initialIsOpen);
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <>
+      <button type="button" onClick={handleToggle}>
+        {toggleText}
+      </button>
+      <Component isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}
+
+export const MoveToQuickChatBottomSheetStory: Story = {
+  render: (args) => <BottomSheetTemplate {...args} />,
+};
+MoveToQuickChatBottomSheetStory.args = {
+  isOpen: false,
+  toggleText: 'Toggle Announcement Bottom Sheet',
+  Component: MoveToQuickChatBottomSheet,
+};
+
+// export const CameraRequestBottomSheetStory: Story = {
+//   render: (args) => <BottomSheetTemplate {...args} />,
+// };
+// CameraRequestBottomSheetStory.args = {
+//   isOpen: false,
+//   toggleText: 'Toggle Camera Request Bottom Sheet',
+//   Component: CameraRequestBottomSheet,
+// };

--- a/src/features/hunterMatching/MoveToQuickChatBottomSheet.tsx
+++ b/src/features/hunterMatching/MoveToQuickChatBottomSheet.tsx
@@ -10,17 +10,19 @@ interface MoveToQuickChatBottomSheetProps {
 
 function MoveToQuickChatBottomSheet({ isOpen, onClose }: MoveToQuickChatBottomSheetProps) {
   return (
-    <BottomSheet isOpen={isOpen} onChange={onClose} hideHandleBar>
+    <BottomSheet isOpen={isOpen} onChange={onClose}>
       <Container
         direction="column"
         justify="flex-start"
         align="flex-start"
         gap="15px"
       >
-        <Heading.H3 weight="bold">퀵챗으로 이동할게요</Heading.H3>
-        <Paragraph variant="medium">헌터와 1대1로 대화하며</Paragraph>
-        <Paragraph variant="medium">빠르게 도움을 요청하세요</Paragraph>
-        <Container direction="column" gap="6px">
+        <Heading.H3_5 weight="bold">퀵챗으로 이동할게요</Heading.H3_5>
+        <Container direction="column" padding="0 0 19px 0" gap="5px">
+          <Paragraph variant="medium" weight="regular">헌터와 1대1로 대화하며</Paragraph>
+          <Paragraph variant="medium" weight="regular">빠르게 도움을 요청하세요</Paragraph>
+        </Container>
+        <Container direction="column">
           <Button>대화하러 가기</Button>
         </Container>
       </Container>

--- a/src/features/hunterMatching/MoveToQuickChatBottomSheet.tsx
+++ b/src/features/hunterMatching/MoveToQuickChatBottomSheet.tsx
@@ -1,0 +1,31 @@
+import Button from '@components/button';
+import BottomSheet from '@components/bottomSheet';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+
+interface MoveToQuickChatBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function MoveToQuickChatBottomSheet({ isOpen, onClose }: MoveToQuickChatBottomSheetProps) {
+  return (
+    <BottomSheet isOpen={isOpen} onChange={onClose} hideHandleBar>
+      <Container
+        direction="column"
+        justify="flex-start"
+        align="flex-start"
+        gap="15px"
+      >
+        <Heading.H3 weight="bold">퀵챗으로 이동할게요</Heading.H3>
+        <Paragraph variant="medium">헌터와 1대1로 대화하며</Paragraph>
+        <Paragraph variant="medium">빠르게 도움을 요청하세요</Paragraph>
+        <Container direction="column" gap="6px">
+          <Button>대화하러 가기</Button>
+        </Container>
+      </Container>
+    </BottomSheet>
+  );
+}
+
+export default MoveToQuickChatBottomSheet;

--- a/src/pages/helpee/ButtonSelector.tsx
+++ b/src/pages/helpee/ButtonSelector.tsx
@@ -34,7 +34,7 @@ const ButtonSelector = forwardRef<HTMLDivElement, ButtonSelectorProps>(({
 
   return (
     <div ref={ref}>
-      <Paragraph>{label}</Paragraph>
+      <Paragraph css={{ marginBottom: '8px' }}>{label}</Paragraph>
       <Container justify="space-between">
         {options.map((option) => (
           <Button

--- a/src/pages/helpee/useFormPageStyle.ts
+++ b/src/pages/helpee/useFormPageStyle.ts
@@ -5,9 +5,9 @@ function useFormPageStyle() {
 
   const inputTextStyle: CSSObject = {
     flexDirection: 'column',
-    gap: '10px',
+    gap: '3px',
     label: {
-      marginTop: '24px',
+      marginBottom: '4px',
       padding: 0,
       color: 'black',
       fontSize: '16px',
@@ -38,19 +38,8 @@ function useFormPageStyle() {
   const inputBtnStyle: CSSObject = {
     flexDirection: 'column',
     alignItems: 'flex-start',
-    marginTop: '20px',
     div: {
-      gap: '15px',
-    },
-    button: {
-      border: `0.5px solid ${theme.colors.primary.main}`,
-      padding: '4px 15px',
-      color: theme.colors.primary.main,
-      fontSize: '14px',
-      '&:hover': {
-        backgroundColor: theme.colors.primary.main,
-        color: 'white',
-      },
+      gap: '18px',
     },
 
   };
@@ -64,6 +53,7 @@ function useFormPageStyle() {
   };
 
   const selectedBtnStyle: CSSObject = {
+    ...inputBtnStyle,
     color: 'white !important',
     backgroundColor: theme.colors.primary.main,
   };

--- a/src/pages/hunterMatching/HuntCancelledPage.stories.tsx
+++ b/src/pages/hunterMatching/HuntCancelledPage.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import HuntCancelledPage from '@pages/hunterMatching/HuntCancelledPage';
+
+const meta: Meta<typeof HuntCancelledPage> = {
+  title: 'Pages/HunterMatching/HuntCancelledPage',
+  component: HuntCancelledPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HuntCancelledPage>;
+
+export const HuntCancelledPageDefault: Story = {
+  args: {
+
+  },
+};

--- a/src/pages/hunterMatching/HuntCancelledPage.tsx
+++ b/src/pages/hunterMatching/HuntCancelledPage.tsx
@@ -1,0 +1,20 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Container from '@components/container';
+import { Heading } from '@components/text';
+import Button from '@components/button';
+
+function HuntCancelledPage() {
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" justify="space-between" padding="96px 0 10px 0" height="100dvh">
+        <Container direction="column" gap="5px">
+          <Heading.H3_5 weight="medium">매칭이 취소되었어요</Heading.H3_5>
+          <Heading.H3_5 weight="medium">다른 사냥을 진행해보세요</Heading.H3_5>
+        </Container>
+        <Button>사냥 목록으로</Button>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+
+export default HuntCancelledPage;

--- a/src/pages/hunterMatching/HunterApprovalPage.stories.tsx
+++ b/src/pages/hunterMatching/HunterApprovalPage.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import HunterApprovalPage from '@pages/hunterMatching/HunterApprovalPage';
+
+const meta: Meta<typeof HunterApprovalPage> = {
+  title: 'Pages/HunterMatching/HunterApprovalPage',
+  component: HunterApprovalPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HunterApprovalPage>;
+
+export const HuntCancelledPageDefault: Story = {
+  args: {
+
+  },
+};

--- a/src/pages/hunterMatching/HunterApprovalPage.tsx
+++ b/src/pages/hunterMatching/HunterApprovalPage.tsx
@@ -1,0 +1,138 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+import Button from '@components/button';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+import Slider from 'react-slick';
+import logo from '@assets/bulning-logo.svg';
+import { css, useTheme } from '@emotion/react';
+
+function HunterApprovalPage() {
+  const theme = useTheme();
+  const settings = {
+    dots: true,
+    infinite: false,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
+  const sliderStyle = css`
+      .slick-dots {
+          li{
+              width: 10px;
+          }
+      }
+  `;
+
+  const subBoxStyle = css`
+    background-color: ${theme.colors.background.darken};
+    color: ${theme.colors.text.subtle};
+    font-size: 12px;
+    border-radius: 7px;
+    margin-top: 16px;
+    line-height: 16px;
+  `;
+  const reviewBoxStyle = css`
+    background-color: ${theme.colors.background.darken};
+    font-size: 12px;
+    border-radius: 7px;
+    margin-top: 18px;
+  `;
+  const commentBoxStyle = css`
+    div {
+      background-color: rgba(130, 152, 183, 0.20);
+      padding: 3px 6px;
+      border-radius: 4px;
+    }
+    color: #012962;
+  `;
+
+  const sectionHeadingStyle = css`
+    font-size: 14px;
+    font-weight: 500; 
+    color: ${theme.colors.text.subtle};
+  `;
+  const sectionContentStyle = css`
+    font-size: 14px;
+    font-weight: 400; 
+  `;
+
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" justify="space-between" height="100dvh" padding="96px 0 10px 0">
+        <Container direction="column" gap="65px">
+          <Container direction="column" gap="8px">
+            <Heading.H3_5>헌터의 정보를 확인하고</Heading.H3_5>
+            <Heading.H3_5>도움 수락 여부를 선택해주세요</Heading.H3_5>
+          </Container>
+          <Slider {...settings} css={sliderStyle}>
+            <Container direction="column" padding="0 0 52px 0">
+              <Container gap="30px">
+                <img
+                  src={logo}
+                  alt="profile-img"
+                  css={{ width: '77px', height: '77px', borderRadius: '100%' }}
+                />
+                <Container direction="column" gap="16px">
+                  <Heading.H5 weight="medium">닉네임</Heading.H5>
+                  <Container gap="25px">
+                    <Container direction="column" gap="7px" width="100px" css={sectionHeadingStyle}>
+                      <div>거주지</div>
+                      <div>회원 정보</div>
+                      <div>평균 별정</div>
+                      <div>거래 횟수</div>
+                    </Container>
+                    <Container direction="column" gap="7px" css={sectionContentStyle}>
+                      <div>부산광역시 금정구 장전2동</div>
+                      <div>여자 | 20대</div>
+                      <div>4.2</div>
+                      <div>10회</div>
+                    </Container>
+                  </Container>
+                </Container>
+              </Container>
+              <Container padding="10px" css={subBoxStyle}>
+                안녕하세요. 장전역 근처에 사는 대학생입니다. 저희 집에 있는 그 거품 나는 스프레이로 깔끔하게 바퀴벌레 처리 가능합니다.
+                호출 받으면 10분 안에 도착할 수 있어요.
+              </Container>
+            </Container>
+            <Container direction="column">
+              <Paragraph>후기</Paragraph>
+              <Container direction="column" padding="12px 20px 9px 12px" gap="5px" css={reviewBoxStyle}>
+                <Container gap="5px" css={{ fontSize: '10px', color: '#848484' }}>
+                  별
+                  <div>24.09.01</div>
+                  <div>금정구 구서1동</div>
+                </Container>
+                신속한 처리와 빠른 거래, 감사합니다.
+                <Container gap="3px" css={commentBoxStyle}>
+                  <div>친절해요.</div>
+                  <div>연락이 빨랐어요.</div>
+                  <div>약속 시간을 잘 지켰어요.</div>
+                </Container>
+              </Container>
+              <Container direction="column" padding="12px 20px 9px 12px" gap="5px" css={reviewBoxStyle}>
+                <Container gap="5px" css={{ fontSize: '10px', color: '#848484' }}>
+                  별
+                  <div>24.09.01</div>
+                  <div>금정구 구서1동</div>
+                </Container>
+                조금 늦게 도착하셨지만 괜찮았어요.!
+                <Container gap="3px" css={commentBoxStyle}>
+                  <div>친절해요.</div>
+                  <div>연락이 빨랐어요.</div>
+                </Container>
+              </Container>
+            </Container>
+          </Slider>
+        </Container>
+        <Container direction="column" gap="6px">
+          <Button>수락하기</Button>
+          <Button variant="secondary">취소하기</Button>
+        </Container>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+export default HunterApprovalPage;

--- a/src/pages/hunterMatching/InfoSentAwaitPage.stories.tsx
+++ b/src/pages/hunterMatching/InfoSentAwaitPage.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import infoSentAwaitPage from '@pages/hunterMatching/InfoSentAwaitPage';
+
+const meta: Meta<typeof infoSentAwaitPage> = {
+  title: 'Pages/HunterMatching/infoSentAwaitPage',
+  component: infoSentAwaitPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof infoSentAwaitPage>;
+
+export const infoSentAwaitScreenDefault: Story = {
+  args: {
+
+  },
+};

--- a/src/pages/hunterMatching/InfoSentAwaitPage.stories.tsx
+++ b/src/pages/hunterMatching/InfoSentAwaitPage.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
-import infoSentAwaitPage from '@pages/hunterMatching/InfoSentAwaitPage';
+import InfoSentAwaitPage from '@pages/hunterMatching/InfoSentAwaitPage';
 
-const meta: Meta<typeof infoSentAwaitPage> = {
-  title: 'Pages/HunterMatching/infoSentAwaitPage',
-  component: infoSentAwaitPage,
+const meta: Meta<typeof InfoSentAwaitPage> = {
+  title: 'Pages/HunterMatching/InfoSentAwaitPage',
+  component: InfoSentAwaitPage,
   parameters: {
     layout: 'fullscreen',
   },
@@ -11,9 +11,9 @@ const meta: Meta<typeof infoSentAwaitPage> = {
 
 export default meta;
 
-type Story = StoryObj<typeof infoSentAwaitPage>;
+type Story = StoryObj<typeof InfoSentAwaitPage>;
 
-export const infoSentAwaitScreenDefault: Story = {
+export const InfoSentAwaitPageDefault: Story = {
   args: {
 
   },

--- a/src/pages/hunterMatching/InfoSentAwaitPage.tsx
+++ b/src/pages/hunterMatching/InfoSentAwaitPage.tsx
@@ -1,0 +1,25 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+import Button from '@components/button';
+import { useTheme } from '@emotion/react';
+
+function InfoSentAwaitPage() {
+  const theme = useTheme();
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" justify="space-between" padding="96px 0 10px 0" height="100dvh">
+        <Container direction="column" gap="5px">
+          <Heading.H3_5 weight="medium">헬피에게 정보를 보냈어요</Heading.H3_5>
+          <Heading.H3_5 weight="medium">이 화면에서 잠시만 기다려주세요</Heading.H3_5>
+        </Container>
+        <Container direction="column" align="center" gap="13px">
+          <Paragraph css={{ fontSize: '12px', color: `${theme.colors.text.subtle}` }}>헬피가 사냥에 동의하면 버튼이 활성화돼요</Paragraph>
+          <Button>확인</Button>
+        </Container>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+
+export default InfoSentAwaitPage;

--- a/src/pages/hunting/HunterInfoInputPage.stories.tsx
+++ b/src/pages/hunting/HunterInfoInputPage.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import HunterInfoInputPage from '@pages/hunting/HunterInfoInputPage';
 
 const meta: Meta<typeof HunterInfoInputPage> = {
-  title: 'Pages/HunterInfoInputPage',
+  title: 'Pages/Hunting/HunterInfoInputPage',
   component: HunterInfoInputPage,
   parameters: {
     layout: 'fullscreen',

--- a/src/pages/hunting/HunterInfoInputPage.tsx
+++ b/src/pages/hunting/HunterInfoInputPage.tsx
@@ -65,79 +65,80 @@ function HunterInfoInputPage() {
   };
 
   return (
-    <DefaultPaddedContainer height="32px" css={{ lineHeight: '32px' }}>
+    <DefaultPaddedContainer>
       <form onSubmit={handleSubmit(onSubmit)} css={{ width: '100%' }}>
-        <Container direction="column">
-          <Container>
-            <img src={close} alt="close" css={{ width: '32px', height: '32px' }} />
-            <Heading.H3 css={{ marginLeft: '62px' }}>헌터 정보 입력</Heading.H3>
-          </Container>
-          <Container direction="column" padding="24px 0">
-            {[
-              {
-                label: '성별', name: 'gender', options: ['남성', '여성'], validation: validations.gender,
-              },
-              {
-                label: '연령대', name: 'age', options: ['20대', '30대', '40대', '50대'], validation: validations.age,
-              },
-            ].map(({
-              label, name, options,
-            }) => (
-              <Container
-                css={inputBtnStyle}
-                key={name}
-              >
-                <ButtonSelector
-                  etcBtn={false}
-                  label={label}
-                  options={options}
-                  setValue={setValue}
-                  {...register(name as keyof HunterInfo, validations[name as keyof HunterInfo])}
-                />
-                <FormErrorMessage errors={errors} name={name} />
-              </Container>
-            ))}
-            <Container css={inputTextStyle}>
-              <Input type="text" label="주소" placeholder="부산광역시 금정구 장전1동" {...register('address', validations.address)} />
-              <FormErrorMessage errors={errors} name="address" />
-              <Input type="text" placeholder="대략적인 위치(ex. 부산대역에서 5분, 대동병원 근처)" {...register('addressDetail', validations.addressDetail)} css={{ marginTop: '3px' }} />
-              <FormErrorMessage errors={errors} name="addressDetail" />
+        <Container direction="column" padding="10px 0 10px 0" height="100dvh" justify="space-between">
+          <Container direction="column">
+            <Container>
+              <img src={close} alt="close" css={{ width: '32px', height: '32px' }} />
+              <Heading.H3 css={{ marginLeft: '62px' }}>헌터 정보 입력</Heading.H3>
             </Container>
-            <Container css={inputTextStyle}>
-              <Paragraph css={{ marginTop: '20px' }}>
-                메모
-              </Paragraph>
-              <textarea
-                placeholder="자기소개와 도움을 줄 수 있는 방법 등을 작성해주세요."
-                {...register('memo', validations.memo)}
-                value={memoValue}
-                onChange={handleMemoChange}
-                css={{
-                  height: '160px',
-                  verticalAlign: 'top',
-                  backgroundColor: '#F2F3F6',
-                  fontSize: '15px',
-                  border: 'none',
-                  borderRadius: '6px',
-                  padding: '10px 13px',
-                }}
-              />
-              <Container justify="space-between">
-                <FormErrorMessage errors={errors} name="memo" />
-                <Paragraph variant="small">
-                  {memoValue.length}
-                  {' '}
-                  / 200자
+            <Container direction="column" padding="50px 0 0 0" gap="35px">
+              {[
+                {
+                  label: '성별', name: 'gender', options: ['남성', '여성'], validation: validations.gender,
+                },
+                {
+                  label: '연령대', name: 'age', options: ['20대', '30대', '40대', '50대'], validation: validations.age,
+                },
+              ].map(({
+                label, name, options,
+              }) => (
+                <Container
+                  css={inputBtnStyle}
+                  key={name}
+                >
+                  <ButtonSelector
+                    etcBtn={false}
+                    label={label}
+                    options={options}
+                    setValue={setValue}
+                    {...register(name as keyof HunterInfo, validations[name as keyof HunterInfo])}
+                  />
+                  <FormErrorMessage errors={errors} name={name} />
+                </Container>
+              ))}
+              <Container css={inputTextStyle}>
+                <Input type="text" label="주소" placeholder="부산광역시 금정구 장전1동" {...register('address', validations.address)} />
+                <FormErrorMessage errors={errors} name="address" />
+                <Input type="text" placeholder="대략적인 위치(ex. 부산대역에서 5분, 대동병원 근처)" {...register('addressDetail', validations.addressDetail)} css={{ marginTop: '3px' }} />
+                <FormErrorMessage errors={errors} name="addressDetail" />
+              </Container>
+              <Container direction="column" gap="4px">
+                <Paragraph>
+                  메모
                 </Paragraph>
+                <textarea
+                  placeholder="자기소개와 도움을 줄 수 있는 방법 등을 작성해주세요."
+                  {...register('memo', validations.memo)}
+                  value={memoValue}
+                  onChange={handleMemoChange}
+                  css={{
+                    height: '160px',
+                    verticalAlign: 'top',
+                    backgroundColor: '#F2F3F6',
+                    fontSize: '15px',
+                    border: 'none',
+                    borderRadius: '6px',
+                    padding: '10px 13px',
+                  }}
+                />
+                <Container justify="space-between">
+                  <FormErrorMessage errors={errors} name="memo" />
+                  <Paragraph variant="small">
+                    {memoValue.length}
+                    {' '}
+                    / 200자
+                  </Paragraph>
+                </Container>
               </Container>
             </Container>
-            <Button
-              type="submit"
-              css={{ borderRadius: '8px', marginTop: '27px', marginBottom: '32px' }}
-            >
-              다음
-            </Button>
           </Container>
+          <Button
+            type="submit"
+          >
+            다음
+          </Button>
         </Container>
       </form>
     </DefaultPaddedContainer>

--- a/src/pages/hunting/HuntingListDetailPage.stories.tsx
+++ b/src/pages/hunting/HuntingListDetailPage.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import HuntingListDetailPage from '@pages/hunting/HuntingListDetailPage';
+
+const meta: Meta<typeof HuntingListDetailPage> = {
+  title: 'Pages/Hunting/HuntingListDetailPage',
+  component: HuntingListDetailPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HuntingListDetailPage>;
+
+export const HuntingListDetailPageDefault: Story = {
+  args: {
+
+  },
+};

--- a/src/pages/hunting/HuntingListDetailPage.tsx
+++ b/src/pages/hunting/HuntingListDetailPage.tsx
@@ -1,0 +1,62 @@
+import { DefaultPaddedContainer } from '@components/container/variants';
+import Container from '@components/container';
+import { Heading, Paragraph } from '@components/text';
+import Button from '@components/button';
+import { useTheme } from '@emotion/react';
+import arrowBack from '@assets/icons/arrow-back.svg';
+import location from '@assets/icons/location.svg';
+
+function HuntingListDetailPage() {
+  const theme = useTheme();
+  return (
+    <DefaultPaddedContainer>
+      <Container direction="column" padding="10px 0 10px 0">
+        <img src={arrowBack} alt="back" css={{ width: '32px', height: '32px' }} />
+        <img src={arrowBack} alt="back" css={{ width: '100%', height: '142px', marginTop: '54px' }} />
+        <Container direction="column" padding="35px 0 30px 0" gap="10px">
+          <Heading.H5 weight="medium">닉네임</Heading.H5>
+          <Heading.H5 weight="medium">바퀴벌레 좀 잡아주세요 빨리ㅠ</Heading.H5>
+          <Container>
+            <Paragraph variant="xsmall">10분 전</Paragraph>
+            <Paragraph color={theme.colors.text.moderate}>&#183;</Paragraph>
+            <img src={location} alt="location" css={{ width: '18px', height: '18px', marginTop: '-3px' }} />
+            <Paragraph variant="xsmall">500m</Paragraph>
+          </Container>
+          <Paragraph variant="large" weight="semi-bold" css={{ marginTop: '8px' }}>12,000원</Paragraph>
+        </Container>
+        <div
+          css={{
+            position: 'relative',
+            left: 'calc(-50vw + 50%)',
+            width: '100vw',
+            height: '10px',
+            backgroundColor: theme.colors.background.darken,
+          }}
+        />
+        <Container padding="23px 0 21px 0">
+          <Container direction="column" gap="15px" width="100px" css={{ color: theme.colors.text.subtle }}>
+            <Paragraph variant="small" weight="semi-bold">종류</Paragraph>
+            <Paragraph variant="small" weight="semi-bold">크기</Paragraph>
+            <Paragraph variant="small" weight="semi-bold">보유 물품</Paragraph>
+          </Container>
+          <Container direction="column" gap="15px">
+            <Paragraph variant="small">바퀴벌레</Paragraph>
+            <Paragraph variant="small">약 500원 동전 크기</Paragraph>
+            <Paragraph variant="small">에프킬라</Paragraph>
+          </Container>
+        </Container>
+        <Container height="0.5px" css={{ background: 'rgba(180, 180, 181, 0.40)' }} />
+        <Container direction="column" padding="20px 0 0 0" gap="5px">
+          <Paragraph variant="small" weight="semi-bold" css={{ color: theme.colors.text.subtle }}>설명</Paragraph>
+          <Paragraph variant="small" css={{ lineHeight: '20px', marginBottom: '10px' }}>지금 바퀴벌레가 나왔는데 보수 더 드릴 수 있으니까 최대한 빨리 와서 잡아주실 분 구해요...... 중문이 있는 집이라서 주방에 가둬놨어요</Paragraph>
+          <Container width="342px" height="152px" css={{ borderRadius: '8px', backgroundColor: 'gray', marginBottom: '5px' }} />
+          <Paragraph variant="small" weight="medium">부산광역시 금정구 장전1동</Paragraph>
+          <Paragraph variant="xsmall">부산대역에서 도보 5분</Paragraph>
+        </Container>
+        <Button css={{ marginTop: '15px' }}>매칭 시작하기</Button>
+      </Container>
+    </DefaultPaddedContainer>
+  );
+}
+
+export default HuntingListDetailPage;

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -16,7 +16,7 @@ const colorTheme: Colors = {
   background: {
     main: '#FFFFFF',
     lighten: '#FFFFFF',
-    darken: '#F2F3F6',
+    darken: '#F0F0F0',
     light_blue: '#F7FAFE',
   },
   border: {

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -10,7 +10,7 @@ const colorTheme: Colors = {
   text: {
     prominent: '#191B1C',
     moderate: '#71787F',
-    subtle: '#B2B6BB',
+    subtle: '#9B9B9B',
     darken_white: '#F7FAFE',
   },
   background: {

--- a/src/styles/colors/index.ts
+++ b/src/styles/colors/index.ts
@@ -16,7 +16,7 @@ const colorTheme: Colors = {
   background: {
     main: '#FFFFFF',
     lighten: '#FFFFFF',
-    darken: '#F2F3F4',
+    darken: '#F2F3F6',
     light_blue: '#F7FAFE',
   },
   border: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,6 +1995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jquery@npm:*":
+  version: 3.5.32
+  resolution: "@types/jquery@npm:3.5.32"
+  dependencies:
+    "@types/sizzle": "npm:*"
+  checksum: 10c0/4a17ad6819b89026c21323656ab01b0b263f9d470910a87c8740920ff98319d503c7352b85b50134a39724ecbfccabc73aa4c741dfdd460cf8bbe714f9259054
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -2083,6 +2092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-slick@npm:^0":
+  version: 0.23.13
+  resolution: "@types/react-slick@npm:0.23.13"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/35dd72dfbac234b8db019fb8af250ac3891e564d13001642353aa0b7c37f6ed1ff1f5e8fa8b034706993c4d27ac1977c031942636cfd05414ee4667d45c8aea6
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:*, @types/react@npm:^18.3.3":
   version: 18.3.10
   resolution: "@types/react@npm:18.3.10"
@@ -2135,6 +2153,22 @@ __metadata:
     "@types/node": "npm:*"
     "@types/send": "npm:*"
   checksum: 10c0/26ec864d3a626ea627f8b09c122b623499d2221bbf2f470127f4c9ebfe92bd8a6bb5157001372d4c4bd0dd37a1691620217d9dc4df5aa8f779f3fd996b1c60ae
+  languageName: node
+  linkType: hard
+
+"@types/sizzle@npm:*":
+  version: 2.3.9
+  resolution: "@types/sizzle@npm:2.3.9"
+  checksum: 10c0/db0277ff62e8ebe6cdae2020fd045fd7fd19f29a3a2ce13c555b14fb00e105e79004883732118b9f2e8b943cb302645e9eddb4e7bdeef1a171da679cd4c32b72
+  languageName: node
+  linkType: hard
+
+"@types/slick-carousel@npm:^1":
+  version: 1.6.40
+  resolution: "@types/slick-carousel@npm:1.6.40"
+  dependencies:
+    "@types/jquery": "npm:*"
+  checksum: 10c0/3e7e9ad518ec19e5afd3b34b8546fe5f190262d8a29640c7aad19ddd1aad1d6a71dcc11a9528bafb9034e9d4031e2b3cc186c1baf5ed95d13a541e4231463d51
   languageName: node
   linkType: hard
 
@@ -3063,6 +3097,8 @@ __metadata:
     "@types/eslint-plugin-jsx-a11y": "npm:^6"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
+    "@types/react-slick": "npm:^0"
+    "@types/slick-carousel": "npm:^1"
     "@typescript-eslint/eslint-plugin": "npm:7.0.0"
     "@typescript-eslint/parser": "npm:^8.7.0"
     "@vitejs/plugin-react-swc": "npm:^3.5.0"
@@ -3082,7 +3118,9 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-hook-form: "npm:^7.53.2"
     react-router-dom: "npm:^7.0.1"
+    react-slick: "npm:^0.30.3"
     reset-css: "npm:^5.0.2"
+    slick-carousel: "npm:^1.8.1"
     storybook: "npm:8.3.6"
     typescript: "npm:^5.5.3"
     typescript-eslint: "npm:^8.0.1"
@@ -3235,6 +3273,13 @@ __metadata:
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
   checksum: 10c0/5faede3d0387058f1a15869984c8350c203092a685f6148fcc4223950743cb9430b35d6ee9227a9ca14a0ecbe41599b313e4ffe51015c79ab849529965457c9f
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.2.5":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -3686,6 +3731,13 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
+"enquire.js@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "enquire.js@npm:2.1.6"
+  checksum: 10c0/3ab739ed0885b5dda973de3fe610d2e3ce261a3ee77321ee4c0c876294c1c37f87f6cccead3ee1de8ead24b31f730586847f89118f083e776677f7c3cd71abaa
   languageName: node
   linkType: hard
 
@@ -5558,6 +5610,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json2mq@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "json2mq@npm:0.2.0"
+  dependencies:
+    string-convert: "npm:^0.2.0"
+  checksum: 10c0/fc9e2f2306572522d3e61d246afdf70b56ca9ea32f4ad5924c30949867851ab59c926bd0ffc821ebb54d32f3e82e95225f3906eacdb3e54c1ad49acdadf7e0c7
+  languageName: node
+  linkType: hard
+
 "json5@npm:^1.0.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
@@ -5660,6 +5721,13 @@ __metadata:
   dependencies:
     p-locate: "npm:^5.0.0"
   checksum: 10c0/d3972ab70dfe58ce620e64265f90162d247e87159b6126b01314dd67be43d50e96a50b517bce2d9452a79409c7614054c277b5232377de50416564a77ac7aad3
+  languageName: node
+  linkType: hard
+
+"lodash.debounce@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "lodash.debounce@npm:4.0.8"
+  checksum: 10c0/762998a63e095412b6099b8290903e0a8ddcb353ac6e2e0f2d7e7d03abd4275fe3c689d88960eb90b0dde4f177554d51a690f22a343932ecbc50a5d111849987
   languageName: node
   linkType: hard
 
@@ -6681,6 +6749,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-slick@npm:^0.30.3":
+  version: 0.30.3
+  resolution: "react-slick@npm:0.30.3"
+  dependencies:
+    classnames: "npm:^2.2.5"
+    enquire.js: "npm:^2.1.6"
+    json2mq: "npm:^0.2.0"
+    lodash.debounce: "npm:^4.0.8"
+    resize-observer-polyfill: "npm:^1.5.0"
+  peerDependencies:
+    react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/7a4cc4f898ede6fd3a0b7ac48921c1021c7ed3bb1eee5d701b7c3d3d53b0d18d20e72aab1dcb8012ff13636b4927c4bcf243fb97258811a9511bed7ab5a6d27d
+  languageName: node
+  linkType: hard
+
 "react@npm:^16.8.0 || ^17.0.0 || ^18.0.0, react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -6778,6 +6862,13 @@ __metadata:
   version: 5.0.2
   resolution: "reset-css@npm:5.0.2"
   checksum: 10c0/390ee3daaa8d42ea18fa572fc3e9dcb0589081599ae2220eeb488077be7d44c2677c29a4b0e776ceb867ae8421e0f8545c3868ce7124a59a31a1f145158dd7db
+  languageName: node
+  linkType: hard
+
+"resize-observer-polyfill@npm:^1.5.0":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 10c0/5e882475067f0b97dc07e0f37c3e335ac5bc3520d463f777cec7e894bb273eddbfecb857ae668e6fb6881fd6f6bb7148246967172139302da50fa12ea3a15d95
   languageName: node
   linkType: hard
 
@@ -7123,6 +7214,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slick-carousel@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "slick-carousel@npm:1.8.1"
+  peerDependencies:
+    jquery: ">=1.8.0"
+  checksum: 10c0/e8c9c9a454c107cfee88689477b453449ed66d5343cf495d3135ec25ea736a0df862f625a9cdc8abd6262629ecef3343c5de686694831f99b13dfe837a1aa587
+  languageName: node
+  linkType: hard
+
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -7245,6 +7345,13 @@ __metadata:
     sb: ./bin/index.cjs
     storybook: ./bin/index.cjs
   checksum: 10c0/f366ab5feeb354200c6df58f6d7bafc146b56af2d72ad93e19438e1750de2185c199fd804da7728ecaba73ef73404a53f0501829c2af6dffff830f848faf198c
+  languageName: node
+  linkType: hard
+
+"string-convert@npm:^0.2.0":
+  version: 0.2.1
+  resolution: "string-convert@npm:0.2.1"
+  checksum: 10c0/00673ed8a3106137395436537ace7d3672c91a3290da73466055daa0134331dc84bc58c54ba2d2ea40711adc5744426d3c8239dbfc30290438fa3e9ff65db528
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
--

## 📝 작업 내용
- 사냥 상세 페이지 (HM-02)
- 사냥 요청 대기 페이지 (HM-04)
- 헌터 수락 페이지 (HM-05, HM-05-01)
- 매칭 취소 페이지 (HM-07)
- 퀵챗 이동 바텀시트 (HM-06)
- 헌터 매칭 취소 바텀시트 (HM-05-02)
- 헌터 정보 입력 페이지 간격 수정
- Paragraph xsmall 추가
- background darken color 수정

## 💬 리뷰 요구사항(선택)
시간관계상 한번에 많은 내용의 PR을 올리게 된 점 죄송합니다.
추후에 별점 컴포넌트 구현 및 지도 연결이 필요합니다.
